### PR TITLE
Fix scoped routing setup.

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -14,10 +14,19 @@ sudo cp /etc/sysctl.conf __sysctl.conf
 sudo cat _sysctl.conf>>__sysctl.conf
 sudo cp __sysctl.conf /etc/sysctl.conf
 
- echo '<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE plist PUBLIC \
- "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd"><plist \
- version="1.0"><dict><key>Kernel \
- Flags</key><string>net.inet.ip.scopedroute=0</string></dict></plist>' > /Library/Preferences/SystemConfiguration/com.apple.Boot.plist
+kernelflags="net.inet.ip.scopedroute=0"
+
+currentflags=`sudo defaults read /Library/Preferences/SystemConfiguration/com.apple.Boot "Kernel Flags"`
+echo $currentflags
+
+if [[ "$currentflags" == "$kernelflags" ]]; then
+	echo "You're already set for scoped routing."
+else
+	sudo defaults write /Library/Preferences/SystemConfiguration/com.apple.Boot "Kernel Flags" $kernelflags
+	echo "To use shim, you'll need to reboot just this once for the kernel flags change to take effect."
+fi
+
+sudo plutil -convert xml1 /Library/Preferences/SystemConfiguration/com.apple.Boot.plist
 
 ./configure_proxy.sh
 


### PR DESCRIPTION
This fixes #2.

The current setup.sh script was installing bad flags in the kernel’s boot.plist. This does it the right way, and if you run setup.sh twice, it won’t tell you to reboot again (you only need to once per kernel flag change, ever).
